### PR TITLE
feat: attachment download endpoint + metadata in thread entries

### DIFF
--- a/api/tickets-attachment-download.php
+++ b/api/tickets-attachment-download.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * API Endpoint: Attachment Download
+ *
+ * Downloads ticket attachment content as base64-encoded JSON response.
+ *
+ * URL: GET /api/tickets-attachment-download.php/{file_id}.json
+ * Permission: can_read_tickets
+ */
+
+declare(strict_types=1);
+
+// Load osTicket bootstrap
+require_once '../main.inc.php';
+
+// Load ApiBootstrap helper
+require_once INCLUDE_DIR . 'plugins/api-endpoints/lib/ApiBootstrap.php';
+
+$bootstrap = ApiBootstrap::initialize();
+
+// Parse file_id from path info
+$params = $bootstrap->parsePathInfo(
+    '#^/(?P<file_id>\d+)\.(?P<format>json|xml)$#',
+    'Invalid URL format. Expected: /api/tickets-attachment-download.php/{file_id}.json'
+);
+
+$bootstrap->requireMethod('GET');
+
+$bootstrap->execute(function () use ($bootstrap, $params) {
+    $controller = $bootstrap->getController();
+    $fileId = (int)$params['file_id'];
+    return $controller->downloadAttachment($fileId);
+});

--- a/controllers/ExtendedTicketApiController.php
+++ b/controllers/ExtendedTicketApiController.php
@@ -542,6 +542,30 @@ class ExtendedTicketApiController extends TicketApiController {
     }
 
     /**
+     * Download attachment content by file ID
+     *
+     * Returns base64-encoded file content with metadata.
+     * Security: Validates API key has read permission and verifies
+     * the file belongs to a ticket attachment (not arbitrary file access).
+     *
+     * @param int $fileId The file ID from ost_file table
+     * @return array {file_id, filename, mime_type, size, content (base64)}
+     * @throws Exception 401 if unauthorized
+     * @throws Exception 403 if file not linked to a ticket attachment
+     * @throws Exception 404 if file not found
+     */
+    public function downloadAttachment(int $fileId): array
+    {
+        $key = $this->requireApiKey();
+        $this->requireReadPermission($key, 'attachments');
+
+        require_once __DIR__ . '/../lib/Services/AttachmentService.php';
+        $attachmentService = AttachmentService::getInstance();
+
+        return $attachmentService->downloadAttachment($fileId);
+    }
+
+    /**
      * Delete a ticket and all associated data
      *
      * @param string|int $ticketNumber Ticket number or internal ticket ID

--- a/htaccess.template
+++ b/htaccess.template
@@ -24,6 +24,9 @@ RewriteRule ^tickets-stats\.php.*$ - [L]
 # Tickets Statuses API endpoint (no path parameter - optional .xml/.json in PATH_INFO)
 RewriteRule ^tickets-statuses\.php.*$ - [L]
 
+# Tickets Attachment Download API endpoint (path parameter: file_id)
+RewriteRule ^tickets-attachment-download\.php/ - [L]
+
 # Tickets Update API endpoint (path parameter: ticket number)
 RewriteRule ^tickets-update\.php/ - [L]
 

--- a/lib/Services/AttachmentService.php
+++ b/lib/Services/AttachmentService.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Attachment Service
+ *
+ * Handles attachment download with security validation.
+ * Ensures file_id belongs to a ticket thread entry before serving content.
+ */
+
+declare(strict_types=1);
+
+class AttachmentService
+{
+    /**
+     * Download attachment by file ID
+     *
+     * Security: Verifies the file belongs to a ticket attachment
+     * before returning content. Prevents arbitrary file access.
+     *
+     * @param int $fileId The file ID from ost_file table
+     * @return array {file_id, filename, mime_type, size, content (base64)}
+     * @throws Exception 400 if file ID invalid
+     * @throws Exception 403 if file not linked to a ticket attachment
+     * @throws Exception 404 if file not found
+     * @throws Exception 500 if file content cannot be read
+     */
+    public function downloadAttachment(int $fileId): array
+    {
+        if ($fileId < 1) {
+            throw new Exception('Invalid file ID', 400);
+        }
+
+        // Security: Verify file belongs to a ticket attachment (not arbitrary ost_file access)
+        if (defined('ATTACHMENT_TABLE')) {
+            $sql = sprintf(
+                "SELECT 1 FROM %s WHERE file_id = %d LIMIT 1",
+                ATTACHMENT_TABLE,
+                $fileId
+            );
+            $result = db_query($sql);
+            if (!$result || !db_fetch_array($result)) {
+                throw new Exception('Attachment not accessible', 403);
+            }
+        }
+
+        // Load file object
+        $file = AttachmentFile::lookup($fileId);
+        if (!$file) {
+            throw new Exception('File not found', 404);
+        }
+
+        // Read file content (safe for files up to ~10 MB)
+        $content = $file->getData();
+        if ($content === false || $content === null) {
+            throw new Exception('Failed to read file content', 500);
+        }
+
+        return [
+            'file_id' => (int)$file->getId(),
+            'filename' => $file->getName(),
+            'mime_type' => $file->getMimeType(),
+            'size' => (int)$file->getSize(),
+            'content' => base64_encode($content),
+        ];
+    }
+
+    // =========================================================================
+    // Singleton Pattern
+    // =========================================================================
+
+    private static ?self $instance = null;
+
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+}

--- a/lib/Services/TicketService.php
+++ b/lib/Services/TicketService.php
@@ -148,6 +148,34 @@ class TicketService
                 $threadEntry['userId'] = $entry->getUserId();
             }
 
+            // Add attachment metadata if thread entry has attachments
+            if (method_exists($entry, 'getAttachments')) {
+                $attachments = $entry->getAttachments();
+                if ($attachments) {
+                    $attachmentMeta = [];
+                    $separates = $attachments->getSeparates();
+                    if ($separates) {
+                        foreach ($separates as $attachment) {
+                            $file = $attachment->getFile();
+                            if ($file) {
+                                $attachmentMeta[] = [
+                                    'id' => (int)$attachment->getId(),
+                                    'file_id' => (int)$file->getId(),
+                                    'filename' => $file->getName(),
+                                    'size' => (int)$file->getSize(),
+                                    'mime_type' => $file->getMimeType(),
+                                    'inline' => (bool)$attachment->isInline(),
+                                ];
+                            }
+                        }
+                    }
+                    if (!empty($attachmentMeta)) {
+                        $threadEntry['attachments'] = $attachmentMeta;
+                        $threadEntry['attachment_count'] = count($attachmentMeta);
+                    }
+                }
+            }
+
             $entries[] = $threadEntry;
         }
 

--- a/tests/Integration/AttachmentMetadataTest.php
+++ b/tests/Integration/AttachmentMetadataTest.php
@@ -1,0 +1,303 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration Tests for Attachment Metadata in Ticket Thread Entries
+ *
+ * Verifies that getTicket() returns attachment metadata for thread entries
+ * that have file attachments, and that entries without attachments
+ * remain unchanged (backward compatibility).
+ */
+class AttachmentMetadataTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Ticket::$mockData = [];
+        Ticket::$mockDataByNumber = [];
+        API::$mockData = [];
+        Dept::$mockData = [];
+        Topic::$mockData = [];
+        Priority::$mockData = [];
+        TicketStatus::$mockData = [];
+        Staff::$mockData = [];
+        Team::$mockData = [];
+        SLA::$mockData = [];
+        AttachmentFile::$mockData = [];
+    }
+
+    /**
+     * Test that thread entries with attachments include attachment metadata
+     */
+    public function testThreadEntryWithAttachmentsIncludesMetadata(): void
+    {
+        // Setup: Create mock attachment file
+        $file = new AttachmentFile([
+            'id' => 42,
+            'name' => 'report.pdf',
+            'mime_type' => 'application/pdf',
+            'size' => 1024,
+            'content' => 'fake-pdf-content',
+        ]);
+        AttachmentFile::$mockData[42] = $file;
+
+        // Create attachment linked to the file
+        $attachment = new Attachment([
+            'id' => 10,
+            'file' => $file,
+            'inline' => false,
+        ]);
+
+        // Create GenericAttachments collection
+        $attachments = new GenericAttachments([$attachment]);
+
+        // Create thread entry WITH attachments
+        $thread = new Thread([
+            new ThreadEntry([
+                'id' => 1,
+                'type' => 'M',
+                'poster' => 'Test User',
+                'body' => 'Please see attached report',
+                'user_id' => 10,
+                'attachments' => $attachments,
+            ]),
+        ]);
+
+        $ticket = new Ticket([
+            'id' => 100,
+            'number' => '900001',
+            'subject' => 'Ticket with attachment',
+            'thread' => $thread,
+        ]);
+        Ticket::$mockDataByNumber['900001'] = $ticket;
+        Ticket::$mockData[100] = $ticket;
+
+        $apiKey = new API([
+            'key' => 'test-api-key',
+            'can_read_tickets' => true,
+        ]);
+        API::$mockData['test-key'] = $apiKey;
+
+        // Execute
+        $controller = new ExtendedTicketApiController();
+        $result = $controller->getTicket('900001');
+
+        // Assert: Thread entry has attachment metadata
+        $entry = $result['thread'][0];
+        $this->assertArrayHasKey('attachments', $entry);
+        $this->assertArrayHasKey('attachment_count', $entry);
+        $this->assertEquals(1, $entry['attachment_count']);
+
+        // Assert: Attachment metadata structure
+        $att = $entry['attachments'][0];
+        $this->assertEquals(10, $att['id']);
+        $this->assertEquals(42, $att['file_id']);
+        $this->assertEquals('report.pdf', $att['filename']);
+        $this->assertEquals(1024, $att['size']);
+        $this->assertEquals('application/pdf', $att['mime_type']);
+        $this->assertFalse($att['inline']);
+    }
+
+    /**
+     * Test that thread entries without attachments do NOT have attachment keys
+     */
+    public function testThreadEntryWithoutAttachmentsHasNoMetadata(): void
+    {
+        $thread = new Thread([
+            new ThreadEntry([
+                'id' => 1,
+                'type' => 'M',
+                'poster' => 'Test User',
+                'body' => 'Just a text message',
+                'user_id' => 10,
+                // No attachments
+            ]),
+        ]);
+
+        $ticket = new Ticket([
+            'id' => 101,
+            'number' => '900002',
+            'subject' => 'Ticket without attachment',
+            'thread' => $thread,
+        ]);
+        Ticket::$mockDataByNumber['900002'] = $ticket;
+        Ticket::$mockData[101] = $ticket;
+
+        $apiKey = new API([
+            'key' => 'test-api-key',
+            'can_read_tickets' => true,
+        ]);
+        API::$mockData['test-key'] = $apiKey;
+
+        // Execute
+        $controller = new ExtendedTicketApiController();
+        $result = $controller->getTicket('900002');
+
+        // Assert: No attachment keys present
+        $entry = $result['thread'][0];
+        $this->assertArrayNotHasKey('attachments', $entry);
+        $this->assertArrayNotHasKey('attachment_count', $entry);
+    }
+
+    /**
+     * Test multiple attachments on a single thread entry
+     */
+    public function testThreadEntryWithMultipleAttachments(): void
+    {
+        $file1 = new AttachmentFile([
+            'id' => 50,
+            'name' => 'image.png',
+            'mime_type' => 'image/png',
+            'size' => 2048,
+            'content' => 'fake-png',
+        ]);
+        $file2 = new AttachmentFile([
+            'id' => 51,
+            'name' => 'document.docx',
+            'mime_type' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'size' => 5120,
+            'content' => 'fake-docx',
+        ]);
+        AttachmentFile::$mockData[50] = $file1;
+        AttachmentFile::$mockData[51] = $file2;
+
+        $attachments = new GenericAttachments([
+            new Attachment(['id' => 20, 'file' => $file1, 'inline' => false]),
+            new Attachment(['id' => 21, 'file' => $file2, 'inline' => false]),
+        ]);
+
+        $thread = new Thread([
+            new ThreadEntry([
+                'id' => 1,
+                'type' => 'M',
+                'poster' => 'User',
+                'body' => 'Two files attached',
+                'user_id' => 10,
+                'attachments' => $attachments,
+            ]),
+        ]);
+
+        $ticket = new Ticket([
+            'id' => 102,
+            'number' => '900003',
+            'subject' => 'Multiple attachments',
+            'thread' => $thread,
+        ]);
+        Ticket::$mockDataByNumber['900003'] = $ticket;
+        Ticket::$mockData[102] = $ticket;
+
+        $apiKey = new API(['key' => 'test-api-key', 'can_read_tickets' => true]);
+        API::$mockData['test-key'] = $apiKey;
+
+        $controller = new ExtendedTicketApiController();
+        $result = $controller->getTicket('900003');
+
+        $entry = $result['thread'][0];
+        $this->assertEquals(2, $entry['attachment_count']);
+        $this->assertCount(2, $entry['attachments']);
+        $this->assertEquals('image.png', $entry['attachments'][0]['filename']);
+        $this->assertEquals('document.docx', $entry['attachments'][1]['filename']);
+    }
+
+    /**
+     * Test that inline attachments are excluded from metadata
+     *
+     * getSeparates() filters out inline attachments (embedded images etc.)
+     */
+    public function testInlineAttachmentsAreExcluded(): void
+    {
+        $inlineFile = new AttachmentFile([
+            'id' => 60,
+            'name' => 'embedded.png',
+            'mime_type' => 'image/png',
+            'size' => 512,
+            'content' => 'fake',
+        ]);
+        $normalFile = new AttachmentFile([
+            'id' => 61,
+            'name' => 'contract.pdf',
+            'mime_type' => 'application/pdf',
+            'size' => 4096,
+            'content' => 'fake',
+        ]);
+        AttachmentFile::$mockData[60] = $inlineFile;
+        AttachmentFile::$mockData[61] = $normalFile;
+
+        $attachments = new GenericAttachments([
+            new Attachment(['id' => 30, 'file' => $inlineFile, 'inline' => true]),
+            new Attachment(['id' => 31, 'file' => $normalFile, 'inline' => false]),
+        ]);
+
+        $thread = new Thread([
+            new ThreadEntry([
+                'id' => 1,
+                'type' => 'M',
+                'poster' => 'User',
+                'body' => 'Mixed attachments',
+                'user_id' => 10,
+                'attachments' => $attachments,
+            ]),
+        ]);
+
+        $ticket = new Ticket([
+            'id' => 103,
+            'number' => '900004',
+            'subject' => 'Inline vs separate',
+            'thread' => $thread,
+        ]);
+        Ticket::$mockDataByNumber['900004'] = $ticket;
+        Ticket::$mockData[103] = $ticket;
+
+        $apiKey = new API(['key' => 'test-api-key', 'can_read_tickets' => true]);
+        API::$mockData['test-key'] = $apiKey;
+
+        $controller = new ExtendedTicketApiController();
+        $result = $controller->getTicket('900004');
+
+        $entry = $result['thread'][0];
+        // Only the non-inline attachment should appear
+        $this->assertEquals(1, $entry['attachment_count']);
+        $this->assertCount(1, $entry['attachments']);
+        $this->assertEquals('contract.pdf', $entry['attachments'][0]['filename']);
+        $this->assertEquals(61, $entry['attachments'][0]['file_id']);
+    }
+
+    /**
+     * Test thread entry with empty GenericAttachments (no files attached)
+     */
+    public function testThreadEntryWithEmptyAttachmentsCollection(): void
+    {
+        $attachments = new GenericAttachments([]);
+
+        $thread = new Thread([
+            new ThreadEntry([
+                'id' => 1,
+                'type' => 'M',
+                'poster' => 'User',
+                'body' => 'Empty attachments',
+                'user_id' => 10,
+                'attachments' => $attachments,
+            ]),
+        ]);
+
+        $ticket = new Ticket([
+            'id' => 104,
+            'number' => '900005',
+            'subject' => 'Empty attachments collection',
+            'thread' => $thread,
+        ]);
+        Ticket::$mockDataByNumber['900005'] = $ticket;
+        Ticket::$mockData[104] = $ticket;
+
+        $apiKey = new API(['key' => 'test-api-key', 'can_read_tickets' => true]);
+        API::$mockData['test-key'] = $apiKey;
+
+        $controller = new ExtendedTicketApiController();
+        $result = $controller->getTicket('900005');
+
+        // Empty collection = no attachment keys
+        $entry = $result['thread'][0];
+        $this->assertArrayNotHasKey('attachments', $entry);
+        $this->assertArrayNotHasKey('attachment_count', $entry);
+    }
+}

--- a/tests/Unit/AttachmentServiceTest.php
+++ b/tests/Unit/AttachmentServiceTest.php
@@ -1,0 +1,172 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+// Load the service
+require_once __DIR__ . '/../../lib/Services/AttachmentService.php';
+
+/**
+ * Unit Tests for AttachmentService
+ *
+ * Tests attachment download logic including:
+ * - Happy path: file lookup and base64 encoding
+ * - Validation: invalid file IDs
+ * - Security: file not found in AttachmentFile::lookup
+ * - Content encoding correctness
+ */
+class AttachmentServiceTest extends TestCase
+{
+    private AttachmentService $service;
+
+    protected function setUp(): void
+    {
+        AttachmentFile::$mockData = [];
+        $this->service = AttachmentService::getInstance();
+    }
+
+    /**
+     * Test successful attachment download returns correct structure
+     */
+    public function testDownloadAttachmentReturnsCorrectData(): void
+    {
+        $content = 'Hello, this is test file content!';
+        $file = new AttachmentFile([
+            'id' => 42,
+            'name' => 'test-document.pdf',
+            'mime_type' => 'application/pdf',
+            'size' => strlen($content),
+            'content' => $content,
+        ]);
+        AttachmentFile::$mockData[42] = $file;
+
+        $result = $this->service->downloadAttachment(42);
+
+        $this->assertEquals(42, $result['file_id']);
+        $this->assertEquals('test-document.pdf', $result['filename']);
+        $this->assertEquals('application/pdf', $result['mime_type']);
+        $this->assertEquals(strlen($content), $result['size']);
+        $this->assertEquals(base64_encode($content), $result['content']);
+    }
+
+    /**
+     * Test that base64 content can be decoded back to original
+     */
+    public function testDownloadAttachmentBase64IsDecodable(): void
+    {
+        $originalContent = "\x89PNG\r\n\x1a\nfake-binary-data";
+        $file = new AttachmentFile([
+            'id' => 43,
+            'name' => 'image.png',
+            'mime_type' => 'image/png',
+            'size' => strlen($originalContent),
+            'content' => $originalContent,
+        ]);
+        AttachmentFile::$mockData[43] = $file;
+
+        $result = $this->service->downloadAttachment(43);
+
+        $decoded = base64_decode($result['content']);
+        $this->assertEquals($originalContent, $decoded);
+    }
+
+    /**
+     * Test 400 error for zero file ID
+     */
+    public function testDownloadAttachmentRejectsZeroFileId(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('Invalid file ID');
+
+        $this->service->downloadAttachment(0);
+    }
+
+    /**
+     * Test 400 error for negative file ID
+     */
+    public function testDownloadAttachmentRejectsNegativeFileId(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('Invalid file ID');
+
+        $this->service->downloadAttachment(-5);
+    }
+
+    /**
+     * Test 404 error when file not found in lookup
+     */
+    public function testDownloadAttachmentReturns404WhenFileNotFound(): void
+    {
+        // No file registered in mockData for ID 999
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+        $this->expectExceptionMessage('File not found');
+
+        $this->service->downloadAttachment(999);
+    }
+
+    /**
+     * Test 500 error when file content is empty (null)
+     */
+    public function testDownloadAttachmentReturns500WhenContentIsNull(): void
+    {
+        $file = new AttachmentFile([
+            'id' => 44,
+            'name' => 'broken.dat',
+            'mime_type' => 'application/octet-stream',
+            'size' => 100,
+            'content' => null,
+        ]);
+        AttachmentFile::$mockData[44] = $file;
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(500);
+        $this->expectExceptionMessage('Failed to read file content');
+
+        $this->service->downloadAttachment(44);
+    }
+
+    /**
+     * Test 500 error when file content is false
+     */
+    public function testDownloadAttachmentReturns500WhenContentIsFalse(): void
+    {
+        $file = new AttachmentFile([
+            'id' => 45,
+            'name' => 'corrupt.dat',
+            'mime_type' => 'application/octet-stream',
+            'size' => 100,
+            'content' => false,
+        ]);
+        AttachmentFile::$mockData[45] = $file;
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(500);
+        $this->expectExceptionMessage('Failed to read file content');
+
+        $this->service->downloadAttachment(45);
+    }
+
+    /**
+     * Test successful download with empty string content (0 bytes is valid)
+     */
+    public function testDownloadAttachmentAcceptsEmptyStringContent(): void
+    {
+        $file = new AttachmentFile([
+            'id' => 46,
+            'name' => 'empty.txt',
+            'mime_type' => 'text/plain',
+            'size' => 0,
+            'content' => '',
+        ]);
+        AttachmentFile::$mockData[46] = $file;
+
+        $result = $this->service->downloadAttachment(46);
+
+        $this->assertEquals(46, $result['file_id']);
+        $this->assertEquals('empty.txt', $result['filename']);
+        $this->assertEquals('', base64_decode($result['content']));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -625,6 +625,79 @@ if (!class_exists('Thread')) {
     }
 }
 
+// Mock AttachmentFile class (represents a stored file in ost_file)
+if (!class_exists('AttachmentFile')) {
+    class AttachmentFile {
+        public static $mockData = [];
+        private $id;
+        private $name;
+        private $mimeType;
+        private $size;
+        private $content;
+
+        public function __construct($data) {
+            $this->id = $data['id'];
+            $this->name = $data['name'] ?? 'unknown';
+            $this->mimeType = $data['mime_type'] ?? 'application/octet-stream';
+            $this->size = $data['size'] ?? 0;
+            $this->content = array_key_exists('content', $data) ? $data['content'] : '';
+        }
+
+        public static function lookup($id) {
+            return self::$mockData[$id] ?? null;
+        }
+
+        public function getId() { return $this->id; }
+        public function getName() { return $this->name; }
+        public function getMimeType() { return $this->mimeType; }
+        public function getType() { return $this->mimeType; }
+        public function getSize() { return $this->size; }
+        public function getData() { return $this->content; }
+    }
+}
+
+// Mock Attachment class (links a file to a thread entry)
+if (!class_exists('Attachment')) {
+    class Attachment {
+        private $id;
+        private $file;
+        private $inline;
+
+        public function __construct($data) {
+            $this->id = $data['id'];
+            $this->file = $data['file'] ?? null;
+            $this->inline = $data['inline'] ?? false;
+        }
+
+        public function getId() { return $this->id; }
+        public function getFile() { return $this->file; }
+        public function isInline() { return $this->inline; }
+    }
+}
+
+// Mock GenericAttachments class (collection of attachments for a thread entry)
+if (!class_exists('GenericAttachments')) {
+    class GenericAttachments {
+        private $attachments;
+
+        public function __construct(array $attachments = []) {
+            $this->attachments = $attachments;
+        }
+
+        public function getSeparates() {
+            return array_filter($this->attachments, fn($a) => !$a->isInline());
+        }
+
+        public function getInlines() {
+            return array_filter($this->attachments, fn($a) => $a->isInline());
+        }
+
+        public function count() {
+            return count($this->getSeparates());
+        }
+    }
+}
+
 // Mock ThreadEntry class
 if (!class_exists('ThreadEntry')) {
     class ThreadEntry {
@@ -638,6 +711,7 @@ if (!class_exists('ThreadEntry')) {
         private $userId;
         private $staff;
         private $ticketId;
+        private $attachments;
 
         public function __construct($data) {
             $this->id = $data['id'];
@@ -649,6 +723,7 @@ if (!class_exists('ThreadEntry')) {
             $this->userId = $data['user_id'] ?? null;
             $this->staff = $data['staff'] ?? null;
             $this->ticketId = $data['ticket_id'] ?? null;
+            $this->attachments = $data['attachments'] ?? null;
         }
 
         public static function lookup($id) {
@@ -664,6 +739,7 @@ if (!class_exists('ThreadEntry')) {
         public function getUserId() { return $this->userId; }
         public function getStaff() { return $this->staff; }
         public function getTicketId() { return $this->ticketId; }
+        public function getAttachments() { return $this->attachments; }
     }
 }
 


### PR DESCRIPTION
## Summary
- New API endpoint `GET /api/tickets-attachment-download.php/{file_id}.json` for downloading ticket attachments as base64-encoded JSON
- Thread entries in ticket GET response now include `attachments` array with metadata (file_id, filename, size, mime_type)
- New `AttachmentService` with security validation (verifies file_id belongs to an actual ticket attachment)

## Changes
- **New:** `lib/Services/AttachmentService.php` — download logic + security check
- **New:** `api/tickets-attachment-download.php` — API endpoint
- **Modified:** `lib/Services/TicketService.php` — attachment metadata in `getThreadEntries()`
- **Modified:** `controllers/ExtendedTicketApiController.php` — `downloadAttachment()` method
- **Modified:** `htaccess.template` — RewriteRule for new endpoint
- **New:** 13 tests (5 integration + 8 unit)

## Test plan
- [x] All 196 PHPUnit tests pass (714 assertions)
- [ ] Deploy to test instance and verify attachment metadata appears in ticket GET
- [ ] Verify attachment download returns correct base64 content
- [ ] Verify security check blocks access to non-attachment files

🤖 Generated with [Claude Code](https://claude.com/claude-code)