### PR TITLE
feat: add email filter to /api/tickets-search.php

### DIFF
--- a/api/tickets-search.php
+++ b/api/tickets-search.php
@@ -29,6 +29,7 @@ $params = $bootstrap->parseQueryParams([
     'limit' => 20,
     'offset' => 0,
     'sort' => 'created',
+    'email' => null,
 ]);
 
 // Execute with standardized error handling

--- a/lib/Services/TicketService.php
+++ b/lib/Services/TicketService.php
@@ -332,6 +332,9 @@ class TicketService
         // Department filter
         $deptFilter = $this->resolveDepartmentFilter($params['department'] ?? null);
 
+        //Email filter
+        $emailFilter = isset($params['email']) ? trim($params['email']) : null;
+
         // Pagination
         $limit = $this->resolvePaginationLimit($params['limit'] ?? null);
         $offset = max(0, (int)($params['offset'] ?? 0));
@@ -345,6 +348,11 @@ class TicketService
         // Filter by query (search in subject)
         if ($query !== null && $query !== '') {
             $tickets = $tickets->filter(['cdata__subject__contains' => $query]);
+        }
+
+        // Filter by email (associated user email)
+        if ($emailFilter !== null && $emailFilter !== '') {
+            $tickets = $tickets->filter(['user__emails__address' => $emailFilter]);
         }
 
         // Filter by status


### PR DESCRIPTION
Adds an optional `email` query parameter to the search endpoint to filter tickets by requester email address.

Follows the same pattern as existing `status` and `department` filters.

Usage:
GET /api/tickets-search.php?email=customer@example.com

Use case: integrating osTicket with an external CRM to automatically display tickets belonging to a specific customer using their email address.