### PR TITLE
fix(stats): cast staff name to string before strcmp

### DIFF
--- a/lib/Services/TicketService.php
+++ b/lib/Services/TicketService.php
@@ -276,7 +276,7 @@ class TicketService
                 if (!isset($staffStats[$staffId])) {
                     $staffStats[$staffId] = [
                         'staff_id' => $staffId,
-                        'staff_name' => $ticket->getStaff()->getName(),
+                        'staff_name' => (string)$ticket->getStaff()->getName(),
                         'total' => 0,
                         'departments' => []
                     ];
@@ -310,7 +310,7 @@ class TicketService
         $stats['by_department'] = $deptStats;
 
         // Sort staff by name and convert to indexed array
-        usort($staffStats, fn($a, $b) => strcmp($a['staff_name'], $b['staff_name']));
+        usort($staffStats, fn($a, $b) => strcmp((string)$a['staff_name'], (string)$b['staff_name']));
         $stats['by_staff'] = array_values($staffStats);
 
         return $stats;


### PR DESCRIPTION
`GET /api/tickets-stats.php` returns HTTP 500 on every call under PHP 8.

```
PHP Fatal error: Uncaught TypeError: strcmp(): Argument #1 ($string1)
must be of type string, AgentsName given
in lib/Services/TicketService.php:313
```

`$ticket->getStaff()->getName()` returns an `AgentsName` object, not a string. It only
survives until something actually treats it as one — `usort()` with `strcmp()` does, and
PHP 8 raises a `TypeError` instead of coercing silently.

Two casts fix it: one where `staff_name` is collected, one in the comparator.

**Environment:** osTicket 1.18.x, PHP 8.x, api-endpoints 2.3.4 (= current `main`).

**Tested:** the endpoint returns JSON again; agents sort correctly, including entries
where no agent is assigned.
