### PR TITLE
fix(bootstrap): catch Throwable instead of Exception

### DIFF
--- a/lib/ApiBootstrap.php
+++ b/lib/ApiBootstrap.php
@@ -229,7 +229,7 @@ class ApiBootstrap
         try {
             $result = $callback();
             $this->sendSuccessResponse($result);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $this->handleException($e);
         }
     }
@@ -260,10 +260,10 @@ class ApiBootstrap
     /**
      * Handle exception and send appropriate error response
      *
-     * @param Exception $e The exception to handle
+     * @param Throwable $e The exception or error to handle
      * @return never
      */
-    public function handleException(Exception $e): never
+    public function handleException(Throwable $e): never
     {
         $code = $e->getCode();
 


### PR DESCRIPTION
`catch (Exception $e)` does not catch `Error`. Since PHP 7 both implement `Throwable`
but they are separate hierarchies, so a `TypeError` walks straight past the handler.

The consequence is not just a different status code: the intended clean 500 with a
message never happens, the `error_log()` line is never reached, and the client gets an
empty 500. The cause is then only visible in the Apache log — which is how the
`strcmp` bug in the companion PR stayed invisible for a while.

Widens the catch and the `handleException()` signature to `Throwable`. Behaviour for
actual `Exception` instances is unchanged, including the 401 rethrow.

**Environment:** osTicket 1.18.x, PHP 8.x, api-endpoints 2.3.4 (= current `main`).
